### PR TITLE
Avoid NPE in Runner#performActions()

### DIFF
--- a/core/src/ca/concordia/jsdeodorant/launcher/Runner.java
+++ b/core/src/ca/concordia/jsdeodorant/launcher/Runner.java
@@ -72,7 +72,9 @@ public abstract class Runner extends CommandLineRunner {
 			LogManager.getLoggerRepository().setThreshold(Level.OFF);
 		addInputsFromFile(analysisOptions.getJsFiles());
 		addInputsFromFile(extractFilesFromLibraries(analysisOptions.getBuiltInLibraries()));
-		addExternsFromFile(analysisOptions.getExterns());
+		List<String> optionsExterns = analysisOptions.getExterns();
+		if (optionsExterns != null)
+			addExternsFromFile(optionsExterns);
 		AnalysisEngine analysisEngine = new AnalysisEngine(createExtendedCompiler(), createOptions(), inputs.build(), externs.build());
 		log.debug("analysis starts");
 		List<Module> results = analysisEngine.run(analysisOptions);


### PR DESCRIPTION
Check analysisOption's externs against null before calling
addExternsFromFile()
