### PR TITLE
Fixed plugin build issue

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,16 +13,23 @@ repositories {
 }
 
 dependencies {
-	compile "com.google.javascript:closure-compiler:v20151216"
-	compile "com.google.guava:guava:18.0"
-	
-    compile group: 'net.sf.opencsv', name: 'opencsv', version:'2.0'
-    compile group: 'log4j', name: 'log4j', version:'1.2.17'
-    compile group: 'com.googlecode.json-simple', name: 'json-simple', version:'1.1'
-    compile group: 'org.postgresql', name: 'postgresql', version:'9.4.1207.jre7'
-    compile group: 'com.crawljax', name: 'crawljax-core', version:'3.6'
-    compile group: 'com.crawljax.plugins', name: 'crawloverview-plugin', version:'3.6'
-    testCompile group: 'junit', name: 'junit', version:'4.11'
+	compile("com.google.javascript:closure-compiler:v20151216")
+	compile("com.google.guava:guava:18.0")
+	compile("org.seleniumhq.selenium:selenium-api:2.53.0") { force = true }
+	compile("org.seleniumhq.selenium:selenium-chrome-driver:2.53.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-firefox-driver:2.53.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-ie-driver:2.53.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-java:2.44.0"){ force = true }
+	compile("org.seleniumhq.selenium:selenium-remote-driver:2.53.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-safari-driver:2.44.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-support:2.53.0") { force = true }
+    compile("net.sf.opencsv:opencsv:2.0")
+    compile("log4j:log4j:1.2.17")
+    compile("com.googlecode.json-simple:json-simple:1.1")
+    compile("org.postgresql:postgresql:9.4.1207.jre7")
+    compile("com.crawljax:crawljax-core:3.6")
+    compile("com.crawljax.plugins:crawloverview-plugin:3.6")
+    testCompile("junit:junit:4.11")
 }
 
 sourceSets {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,20 +16,20 @@ dependencies {
 	compile("com.google.javascript:closure-compiler:v20151216")
 	compile("com.google.guava:guava:18.0")
 	compile("org.seleniumhq.selenium:selenium-api:2.53.0") { force = true }
-	compile("org.seleniumhq.selenium:selenium-chrome-driver:2.53.0") { force = true}
-	compile("org.seleniumhq.selenium:selenium-firefox-driver:2.53.0") { force = true}
-	compile("org.seleniumhq.selenium:selenium-ie-driver:2.53.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-chrome-driver:2.53.0") { force = true }
+	compile("org.seleniumhq.selenium:selenium-firefox-driver:2.53.0") { force = true }
+	compile("org.seleniumhq.selenium:selenium-ie-driver:2.53.0") { force = true }
 	compile("org.seleniumhq.selenium:selenium-java:2.44.0"){ force = true }
-	compile("org.seleniumhq.selenium:selenium-remote-driver:2.53.0") { force = true}
-	compile("org.seleniumhq.selenium:selenium-safari-driver:2.44.0") { force = true}
+	compile("org.seleniumhq.selenium:selenium-remote-driver:2.53.0") { force = true }
+	compile("org.seleniumhq.selenium:selenium-safari-driver:2.44.0") { force = true }
 	compile("org.seleniumhq.selenium:selenium-support:2.53.0") { force = true }
-    compile("net.sf.opencsv:opencsv:2.0")
-    compile("log4j:log4j:1.2.17")
-    compile("com.googlecode.json-simple:json-simple:1.1")
-    compile("org.postgresql:postgresql:9.4.1207.jre7")
-    compile("com.crawljax:crawljax-core:3.6")
-    compile("com.crawljax.plugins:crawloverview-plugin:3.6")
-    testCompile("junit:junit:4.11")
+	compile("net.sf.opencsv:opencsv:2.0")
+	compile("log4j:log4j:1.2.17")
+	compile("com.googlecode.json-simple:json-simple:1.1")
+	compile("org.postgresql:postgresql:9.4.1207.jre7")
+	compile("com.crawljax:crawljax-core:3.6")
+	compile("com.crawljax.plugins:crawloverview-plugin:3.6")
+	testCompile("junit:junit:4.11")
 }
 
 sourceSets {


### PR DESCRIPTION
The problem happened because of the latest update to Selenium. We transitively depend on Selenium (via Crawljax), but Crawljax depends on the latest version of Selenium. Because (for the moment) we are not generating the .classpath file for Eclipse, the versions of all dependencies are hard-coded in this file. Whenever a new version of Selenium comes out, the latest version is fetched (when building), and the .jar file names will be different. Consequently, the update to Selenium would break the building of the Eclipse plugin.

For now, I hard-coded the versions in build.gradle and forced the versions, so that future updates will not break the dependencies in the Eclipse plugin